### PR TITLE
refactor: Store => SnapshotStore + EventStore

### DIFF
--- a/packages/@ddes/aws-lambda-transformer/lib/cli.ts
+++ b/packages/@ddes/aws-lambda-transformer/lib/cli.ts
@@ -11,7 +11,7 @@ import LambdaTransformer from './LambdaTransformer'
 const cli = {
   commands: {
     'transform:lambda': {
-      description: 'Transform store in using AWS lambda',
+      description: 'Transform EventStore using AWS lambda workers',
 
       usage() {
         return '<path-to-transformation-file> [--transformerOption=value]'

--- a/packages/@ddes/aws-lambda-transformer/package.json
+++ b/packages/@ddes/aws-lambda-transformer/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=8.10"
   },
-  "description": "AWS Lambda based Store Mutator for DDES, a framework for distributed Event Sourcing & CQRS",
+  "description": "EventStore transformer powered by AWS Lambda workers for DDES, a framework for distributed Event Sourcing & CQRS",
   "author": "Trym Skaar <trym.skaar@gmail.com>",
   "license": "MIT",
   "files": [

--- a/packages/@ddes/aws-store/README.md
+++ b/packages/@ddes/aws-store/README.md
@@ -1,6 +1,6 @@
 # @ddes/aws-store
 
-> AWS Store and MetaStore implementations for DDES, a framework for distributed Event Sourcing & CQRS.
+> AWS powered EventStore, SnapshotStore and MetaStore implementations for DDES, a framework for distributed Event Sourcing & CQRS.
 
 ## [API Docs](https://s3-eu-west-1.amazonaws.com/ddes-docs/latest/index.html)
 

--- a/packages/@ddes/aws-store/lib/AwsEventStoreBatchMutator.ts
+++ b/packages/@ddes/aws-store/lib/AwsEventStoreBatchMutator.ts
@@ -5,20 +5,20 @@
 import {BatchMutator, Commit} from '@ddes/core'
 import * as debug from 'debug'
 import * as equal from 'fast-deep-equal'
-import AwsStore from './AwsStore'
-import {AwsStoreBatchMutatorQueueItem, MarshalledCommit} from './types'
+import AwsEventStore from './AwsEventStore'
+import {AwsEventStoreBatchMutatorQueueItem, MarshalledCommit} from './types'
 import {marshallCommit} from './utils'
 
 /**
  * @hidden
  */
-const log = debug('@ddes/aws-store:AwsStoreBatchMutator')
+const log = debug('@ddes/aws-store:AwsEventStoreBatchMutator')
 
-export default class AwsStoreBatchMutator extends BatchMutator<
+export default class AwsEventStoreBatchMutator extends BatchMutator<
   MarshalledCommit
 > {
-  protected store: AwsStore
-  protected queue: Set<AwsStoreBatchMutatorQueueItem> = new Set()
+  protected store: AwsEventStore
+  protected queue: Set<AwsEventStoreBatchMutatorQueueItem> = new Set()
   protected maxItemsPerRequest: number = 25
   protected processQueueRunning: boolean = false
   protected capacityLimit?: number
@@ -28,7 +28,7 @@ export default class AwsStoreBatchMutator extends BatchMutator<
     units: number
   }
 
-  constructor(params: {store: AwsStore; capacityLimit?: number}) {
+  constructor(params: {store: AwsEventStore; capacityLimit?: number}) {
     super()
     const {store, capacityLimit} = params
     this.store = store
@@ -165,7 +165,7 @@ export default class AwsStoreBatchMutator extends BatchMutator<
         capacityLeft = this.remainingCapacity.units
       }
 
-      let queueItemsToProcess: AwsStoreBatchMutatorQueueItem[] = []
+      let queueItemsToProcess: AwsEventStoreBatchMutatorQueueItem[] = []
 
       let processingCount = 0
       log(`pending items ${this.pendingItems.length}`)
@@ -222,7 +222,7 @@ export default class AwsStoreBatchMutator extends BatchMutator<
     }
   }
 
-  private sendRequest(queueItemsToSend: AwsStoreBatchMutatorQueueItem[]) {
+  private sendRequest(queueItemsToSend: AwsEventStoreBatchMutatorQueueItem[]) {
     log(`Sending request with ${queueItemsToSend.length} items`)
     const requestPromise = this.store.dynamodb
       .batchWriteItem({

--- a/packages/@ddes/aws-store/lib/AwsEventStoreQueryResponse.ts
+++ b/packages/@ddes/aws-store/lib/AwsEventStoreQueryResponse.ts
@@ -9,21 +9,21 @@ import {
   StoreQueryResultSet,
 } from '@ddes/core'
 import {DynamoDB} from 'aws-sdk'
-import AwsStore from './AwsStore'
+import AwsEventStore from './AwsEventStore'
 import {MarshalledCommit} from './types'
 import {unmarshallCommit} from './utils'
 
-export default class AwsStoreQueryResponse implements StoreQueryResponse {
+export default class AwsEventStoreQueryResponse implements StoreQueryResponse {
   private responseIterator: AsyncIterableIterator<
     DynamoDB.QueryOutput & {
       throttleCount: number
     }
   >
 
-  private store: AwsStore
+  private store: AwsEventStore
 
   constructor(
-    store: AwsStore,
+    store: AwsEventStore,
     responseIterator: AsyncIterableIterator<
       DynamoDB.QueryOutput & {throttleCount: number}
     >

--- a/packages/@ddes/aws-store/lib/AwsMetaStore.ts
+++ b/packages/@ddes/aws-store/lib/AwsMetaStore.ts
@@ -8,6 +8,9 @@ import {ConfigurationOptions} from 'aws-sdk/lib/config'
 import {AutoscalingConfig, StoreCapacityConfig} from './types'
 import * as utils from './utils'
 
+/**
+ * Interface for MetaStore powered by AWS DynamoDB
+ */
 export default class AwsMetaStore extends MetaStore {
   public tableName!: string
 

--- a/packages/@ddes/aws-store/lib/AwsSnapshotStore.ts
+++ b/packages/@ddes/aws-store/lib/AwsSnapshotStore.ts
@@ -1,0 +1,173 @@
+/**
+ * @module @ddes/aws-store
+ */
+
+import {
+  AggregateKey,
+  AggregateSnapshot,
+  AggregateType,
+  Timestamp,
+  utils as coreutils,
+} from '@ddes/core'
+
+import {SnapshotStore} from '@ddes/core'
+import {S3} from 'aws-sdk'
+import {ConfigurationOptions} from 'aws-sdk/lib/config'
+import {createBucket, deleteBucket} from './utils'
+
+/**
+ * Interface for SnapshotStore powered by AWS S3
+ */
+export default class AwsSnapshotStore extends SnapshotStore {
+  public manageBucket: boolean = false
+  public bucketName: string
+  public keyPrefix: string = ''
+  public s3ClientConfiguration?: S3.ClientConfiguration
+  public awsConfig?: ConfigurationOptions
+  public s3: S3
+
+  constructor(config: {
+    bucketName: string
+    manageBucket?: boolean
+    keyPrefix?: string
+    s3ClientConfiguration?: S3.ClientConfiguration
+  }) {
+    super()
+    this.bucketName = config.bucketName
+    this.s3ClientConfiguration = config.s3ClientConfiguration
+    this.s3 = new S3(this.s3ClientConfiguration)
+    if (typeof config.manageBucket !== 'undefined') {
+      this.manageBucket = config.manageBucket
+    }
+  }
+
+  /**
+   * Create and configure DynamoDB table, S3 bucket and DynamoDB auto-scaling
+   */
+  public async setup() {
+    if (this.manageBucket) {
+      await createBucket(this.bucketName, {
+        s3ClientConfiguration: this.s3ClientConfiguration,
+      })
+    }
+  }
+
+  /**
+   * Remove DynamoDB auto-scaling, S3 Bucket and DynamoDB table
+   */
+  public async teardown() {
+    if (this.manageBucket) {
+      await deleteBucket(this.bucketName, {
+        s3ClientConfiguration: this.s3ClientConfiguration,
+      })
+    }
+  }
+
+  /**
+   * Read an aggregate instance snapshot from AWS S3
+   *
+   * @param type e.g. 'Account'
+   * @param key  e.g. '1234'
+   */
+  public async readSnapshot(
+    type: AggregateType,
+    key: AggregateKey
+  ): Promise<AggregateSnapshot | null> {
+    try {
+      const {Body: snapshotJSON} = await this.s3
+        .getObject({
+          Bucket: this.bucketName,
+          Key: `${this.keyPrefix}${type}_${key}`,
+        })
+        .promise()
+
+      if (!snapshotJSON) {
+        return null
+      }
+
+      const {
+        version,
+        state,
+        timestamp: timestampString,
+        compatibilityChecksum,
+      } = JSON.parse(snapshotJSON as string)
+
+      return {
+        version,
+        state,
+        timestamp: coreutils.toTimestamp(timestampString),
+        compatibilityChecksum,
+      }
+    } catch (error) {
+      if (error.code !== 'NoSuchKey') {
+        throw error
+      }
+
+      return null
+    }
+  }
+
+  /**
+   * Delete snapshots from AWS S3 bucket
+   */
+  public async deleteSnapshots() {
+    let listResult
+
+    do {
+      listResult = await this.s3
+        .listObjectsV2({
+          Bucket: this.bucketName,
+          Prefix: this.keyPrefix,
+          ContinuationToken: listResult
+            ? listResult.NextContinuationToken
+            : undefined,
+        })
+        .promise()
+
+      if (!listResult.Contents) {
+        throw new Error('List request returned on content')
+      }
+
+      for (const s3Object of listResult.Contents) {
+        await this.s3
+          .deleteObject({
+            Bucket: this.bucketName,
+            Key: s3Object.Key!,
+          })
+          .promise()
+      }
+    } while (listResult.NextContinuationToken)
+  }
+
+  /**
+   * Write an aggregate instance snapshot to AWS S3 bucket
+   *
+   * @param type e.g. 'Account'
+   * @param key  e.g. '1234'
+   */
+  public async writeSnapshot(
+    type: string,
+    key: string,
+    payload: {
+      version: number
+      state: object
+      timestamp: Timestamp
+      compatibilityChecksum: string
+    }
+  ) {
+    const {version, state, timestamp, compatibilityChecksum} = payload
+
+    await this.s3
+      .putObject({
+        Bucket: this.bucketName,
+        Key: `${this.keyPrefix}${type}_${key}`,
+        Body: JSON.stringify({
+          version,
+          state,
+          compatibilityChecksum,
+          timestamp,
+        }),
+      })
+      .promise()
+  }
+}

--- a/packages/@ddes/aws-store/lib/index.ts
+++ b/packages/@ddes/aws-store/lib/index.ts
@@ -4,9 +4,12 @@
 
 import * as utils from './utils'
 
-export {default as AwsStore} from './AwsStore'
+export {default as AwsEventStore} from './AwsEventStore'
 export {default as AwsMetaStore} from './AwsMetaStore'
-export {default as AwsStoreQueryResponse} from './AwsStoreQueryResponse'
+export {default as AwsSnapshotStore} from './AwsSnapshotStore'
+export {
+  default as AwsEventStoreQueryResponse,
+} from './AwsEventStoreQueryResponse'
 
 export * from './types'
 export {utils}

--- a/packages/@ddes/aws-store/lib/types.ts
+++ b/packages/@ddes/aws-store/lib/types.ts
@@ -27,11 +27,10 @@ export interface AutoscalingConfig {
   utilizationTargetInPercent: number
 }
 
-export interface AwsStoreConfig {
+export interface AwsEventStoreConfig {
   tableName: string
   initialCapacity?: StoreCapacityConfig
   autoscaling?: AutoscalingConfig
-  snapshots?: SnapshotsConfig
   awsConfig?: ConfigurationOptions
   s3ClientConfiguration?: S3.ClientConfiguration
   dynamodbClientConfiguration?: DynamoDB.ClientConfiguration
@@ -113,12 +112,6 @@ export interface MarshalledCommit extends DynamoDB.AttributeMap {
   }
 }
 
-export interface SnapshotsConfig {
-  s3BucketName: string
-  keyPrefix?: string
-  manageBucket?: boolean
-}
-
 export interface StoreQueryParams {
   startKey?: DynamoDB.Key
   keyExpressions?: string[]
@@ -132,7 +125,7 @@ export interface StoreQueryParams {
 /**
  * @hidden
  */
-export interface AwsStoreBatchMutatorQueueItem {
+export interface AwsEventStoreBatchMutatorQueueItem {
   startedPromise: Promise<any>
   startedResolver: () => void
   processedPromise: Promise<any>

--- a/packages/@ddes/aws-store/package.json
+++ b/packages/@ddes/aws-store/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=8.10"
   },
-  "description": "AWS Store and MetaStore implementations for DDES, a framework for distributed Event Sourcing & CQRS",
+  "description": "AWS powered EventStore, SnapshotStore and MetaStore implementations for DDES, a framework for distributed Event Sourcing & CQRS",
   "author": "Trym Skaar <trym.skaar@gmail.com>",
   "license": "MIT",
   "files": [

--- a/packages/@ddes/core/lib/EventStore.ts
+++ b/packages/@ddes/core/lib/EventStore.ts
@@ -14,16 +14,16 @@ import {
 } from './types'
 
 /**
- * Abstract class representing an Event Store
+ * Abstract interface for an Event Store
  */
-export default abstract class Store {
+export default abstract class EventStore {
   /**
    * Performs necessary orchestration to ready the store
    */
   public abstract setup(): Promise<void>
 
   /**
-   * Tears down all resources within namespace created by store
+   * Tears down all resources created by the store
    */
   public abstract teardown(): Promise<void>
 
@@ -89,39 +89,6 @@ export default abstract class Store {
     limit?: number
     capacityLimit?: number
   }): StoreQueryResponse
-
-  /**
-   * Write an aggregate instance snapshot to the store
-   *
-   * @param type e.g. 'Account'
-   * @param key  e.g. '1234'
-   */
-  public abstract writeSnapshot(
-    type: string,
-    key: string,
-    payload: {
-      version: number
-      state: object
-      timestamp: Timestamp
-      compatibilityChecksum: string
-    }
-  ): Promise<void>
-
-  /**
-   * Read an aggregate instance snapshot from store
-   *
-   * @param type e.g. 'Account'
-   * @param key  e.g. '1234'
-   */
-  public abstract readSnapshot(
-    type: AggregateType,
-    key: AggregateKey
-  ): Promise<AggregateSnapshot | null>
-
-  /**
-   * Delete store snapshots
-   */
-  public abstract deleteSnapshots(): Promise<void>
 
   /**
    * Get a [[BatchMutator]] for the store

--- a/packages/@ddes/core/lib/MetaStore.ts
+++ b/packages/@ddes/core/lib/MetaStore.ts
@@ -9,7 +9,7 @@ export default abstract class MetaStore {
   public abstract async put(
     key: MetaStoreKey,
     value: any,
-    options?: {expiresAt?: Date}
+    options?: {expiresAt?: Date | number}
   ): Promise<void>
 
   public abstract async delete(key: MetaStoreKey): Promise<void>

--- a/packages/@ddes/core/lib/SnapshotStore.ts
+++ b/packages/@ddes/core/lib/SnapshotStore.ts
@@ -1,0 +1,58 @@
+/**
+ * @module @ddes/core
+ */
+
+import {
+  AggregateKey,
+  AggregateSnapshot,
+  AggregateType,
+  Timestamp,
+} from './types'
+
+/**
+ * Abstract interface for a store that holds aggregate snapshots
+ */
+export default abstract class SnapshotStore {
+  /**
+   * Performs necessary orchestration to ready the store
+   */
+  public abstract setup(): Promise<void>
+
+  /**
+   * Tears down all resources created by the store
+   */
+  public abstract teardown(): Promise<void>
+
+  /**
+   * Write an aggregate instance snapshot to the store
+   *
+   * @param type e.g. 'Account'
+   * @param key  e.g. '1234'
+   */
+  public abstract writeSnapshot(
+    type: string,
+    key: string,
+    payload: {
+      version: number
+      state: object
+      timestamp: Timestamp
+      compatibilityChecksum: string
+    }
+  ): Promise<void>
+
+  /**
+   * Read an aggregate instance snapshot from store
+   *
+   * @param type e.g. 'Account'
+   * @param key  e.g. '1234'
+   */
+  public abstract readSnapshot(
+    type: AggregateType,
+    key: AggregateKey
+  ): Promise<AggregateSnapshot | null>
+
+  /**
+   * Delete store snapshots
+   */
+  public abstract deleteSnapshots(): Promise<void>
+}

--- a/packages/@ddes/core/lib/StorePoller.ts
+++ b/packages/@ddes/core/lib/StorePoller.ts
@@ -4,7 +4,7 @@
 
 import * as debug from 'debug'
 import Commit from './Commit'
-import Store from './Store'
+import EventStore from './EventStore'
 import {
   AggregateEventUpcasters,
   AggregateType,
@@ -14,7 +14,7 @@ import upcastCommits from './upcastCommits'
 import * as utils from './utils'
 
 export default class StorePoller {
-  public store: Store
+  public eventStore: EventStore
   public sortKeyCursor!: string | Date
 
   protected debug: debug.IDebugger
@@ -50,9 +50,9 @@ export default class StorePoller {
   protected initialPoll: boolean = true
 
   constructor(params: StorePollerParams) {
-    const {store, ...rest} = params
+    const {eventStore, ...rest} = params
 
-    this.store = store
+    this.eventStore = eventStore
     Object.assign(this, rest)
 
     if (params.sortKeyCursor) {
@@ -97,7 +97,7 @@ export default class StorePoller {
 
       while (this.shouldPoll) {
         let commitsCount = 0
-        for await (const resultSet of this.store.chronologicalQuery({
+        for await (const resultSet of this.eventStore.chronologicalQuery({
           min: this.sortKeyCursor,
           exclusiveMin: true,
           group: this.chronologicalGroup,

--- a/packages/@ddes/core/lib/index.ts
+++ b/packages/@ddes/core/lib/index.ts
@@ -3,13 +3,14 @@
  */
 
 export {default as Aggregate} from './Aggregate'
-export {default as Store} from './Store'
+export {default as EventStore} from './EventStore'
 export {default as Commit} from './Commit'
 export {default as BatchMutator} from './BatchMutator'
 export {default as KeySchema} from './KeySchema'
 export {default as Projection} from './Projection'
 export {default as Projector} from './Projector'
 export {default as ProjectionWorker} from './ProjectionWorker'
+export {default as SnapshotStore} from './SnapshotStore'
 export {default as StorePoller} from './StorePoller'
 export {default as MetaStore} from './MetaStore'
 export {default as retryCommand} from './retryCommand'

--- a/packages/@ddes/core/lib/types.ts
+++ b/packages/@ddes/core/lib/types.ts
@@ -4,8 +4,8 @@
 
 import Aggregate from './Aggregate'
 import Commit from './Commit'
+import EventStore from './EventStore'
 import MetaStore from './MetaStore'
-import Store from './Store'
 
 export interface Event {
   type: string
@@ -126,7 +126,7 @@ export interface StoreQueryResponse {
 export type MarshalledCommit = any
 
 export interface StorePollerParams {
-  store: Store
+  eventStore: EventStore
   chronologicalGroup?: string
   sortKeyCursor?: string | Date
   initalSleepPeriod?: number

--- a/packages/@ddes/store-transformations/README.md
+++ b/packages/@ddes/store-transformations/README.md
@@ -1,6 +1,6 @@
 # @ddes/store-transformations
 
-> Store transformations for DDES, a framework for distributed Event Sourcing & CQRS.
+> EventStore transformations for DDES, a framework for distributed Event Sourcing & CQRS.
 
 ## [API Docs](https://s3-eu-west-1.amazonaws.com/ddes-docs/latest/index.html)
 

--- a/packages/@ddes/store-transformations/lib/CommitTransformation.ts
+++ b/packages/@ddes/store-transformations/lib/CommitTransformation.ts
@@ -2,7 +2,7 @@
  * @module @ddes/store-transformations
  */
 
-import {AggregateType, Commit, MarshalledCommit, Store} from '@ddes/core'
+import {AggregateType, Commit, EventStore, MarshalledCommit} from '@ddes/core'
 import * as debug from 'debug'
 import {TransformationWorkerInput} from '.'
 import Transformation from './Transformation'
@@ -20,8 +20,8 @@ const log = debug('@ddes/store-transformations:CommitTransformation')
  * export default new CommitTransformation({
  *   name: 'Do something',
  *
- *   source: new AwsStore({tableName: 'tableA'}),
- *   target: new AwsStore({tableName: 'tableB'}),
+ *   source: new AwsEventStore({tableName: 'tableA'}),
+ *   target: new AwsEventStore({tableName: 'tableB'}),
  *
  *   async transform(commit: Commit) {
  *     // return the output commits of this commit transformation
@@ -43,8 +43,8 @@ class CommitTransformation extends Transformation {
 
   constructor(transformationSpec: {
     name: string
-    source: Store
-    target: Store
+    source: EventStore
+    target: EventStore
     transform: (
       commit: MarshalledCommit | Commit
     ) => Promise<Array<MarshalledCommit | Commit>>

--- a/packages/@ddes/store-transformations/lib/Transformation.ts
+++ b/packages/@ddes/store-transformations/lib/Transformation.ts
@@ -2,19 +2,19 @@
  * @module @ddes/store-transformations
  */
 
-import {Store} from '@ddes/core'
+import {EventStore} from '@ddes/core'
 import {TransformationWorkerInput, TransformationWorkerResult} from './types'
 
 /**
- * Base transformation class, can be used/extended for custom [[Store]] transformations.
+ * Base transformation class, can be used/extended for custom [[EventStore]] transformations.
  * Is most useful when used in conjunction with a [[Transformer]].
  *
  * ```typescript
  * export default new Transformation({
  *   name: 'My custom transformation',
  *
- *   source: new AwsStore({tableName: 'tableA'}),
- *   target: new AwsStore({tableName: 'tableB'}),
+ *   source: new AwsEventStore({tableName: 'tableA'}),
+ *   target: new AwsEventStore({tableName: 'tableB'}),
  *
  *   async perform(input) {
  *     // do work within deadline
@@ -25,14 +25,14 @@ import {TransformationWorkerInput, TransformationWorkerResult} from './types'
  */
 class Transformation {
   public name: string
-  public source: Store
-  public target: Store
+  public source: EventStore
+  public target: EventStore
   public transformerConfig?: any
 
   constructor(transformationSpec: {
     name: string
-    source: Store
-    target: Store
+    source: EventStore
+    target: EventStore
     perform?: Transformation['perform']
     transformerConfig?: any
   }) {

--- a/packages/@ddes/store-transformations/lib/TransformerGui.ts
+++ b/packages/@ddes/store-transformations/lib/TransformerGui.ts
@@ -45,7 +45,7 @@ export default class TransformerGui {
       useBCE: true,
       autoPadding: true,
       warnings: true,
-      title: 'DDES Store Transformer',
+      title: 'DDES EventStore Transformer',
     })
 
     this.setupUI()
@@ -104,7 +104,7 @@ export default class TransformerGui {
       .append(
         blessed.text({
           left: 'center',
-          content: 'DDES Store Transformer',
+          content: 'DDES EventStore Transformer',
           style: {fg: 'blue'},
         })
       )

--- a/packages/@ddes/store-transformations/package.json
+++ b/packages/@ddes/store-transformations/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=8.10"
   },
-  "description": "Store transformations for DDES, a framework for distributed Event Sourcing & CQRS",
+  "description": "EventStore transformations for DDES, a framework for distributed Event Sourcing & CQRS",
   "author": "Trym Skaar <trym.skaar@gmail.com>",
   "license": "MIT",
   "files": [

--- a/tests/packages/aws-store/setup.test.ts
+++ b/tests/packages/aws-store/setup.test.ts
@@ -1,9 +1,9 @@
 import {describeWithResources} from 'support'
-import {aws as AwsTestStore} from 'support/stores'
+import {aws} from 'support/stores'
 
-describeWithResources('AwsStore', {}, context => {
+describeWithResources('AwsEventStore', {}, context => {
   test.concurrent('setup() [withServices]', async () => {
-    const store = AwsTestStore(context, {
+    const eventStore = aws.eventStore(context, {
       initialCapacity: {
         tableRead: 1,
         tableWrite: 2,
@@ -14,10 +14,10 @@ describeWithResources('AwsStore', {}, context => {
       },
     })
 
-    await store.setup()
+    await eventStore.setup()
 
-    const {Table} = await store.dynamodb
-      .describeTable({TableName: store.tableName})
+    const {Table} = await eventStore.dynamodb
+      .describeTable({TableName: eventStore.tableName})
       .promise()
 
     expect(Table).toBeDefined()
@@ -70,6 +70,6 @@ describeWithResources('AwsStore', {}, context => {
       {AttributeName: 'v', KeyType: 'RANGE'},
     ])
 
-    await store.teardown()
+    await eventStore.teardown()
   })
 })

--- a/tests/packages/aws-store/teardown.test.ts
+++ b/tests/packages/aws-store/teardown.test.ts
@@ -1,9 +1,9 @@
 import {describeWithResources} from 'support'
-import {aws as AwsTestStore} from 'support/stores'
+import {aws} from 'support/stores'
 
-describeWithResources('AwsStore', {}, context => {
+describeWithResources('AwsEventStore', {}, context => {
   test('teardown() [withServices]', async () => {
-    const store = AwsTestStore(context, {
+    const eventStore = aws.eventStore(context, {
       initialCapacity: {
         tableRead: 1,
         tableWrite: 2,
@@ -13,11 +13,13 @@ describeWithResources('AwsStore', {}, context => {
         instancesWrite: 6,
       },
     })
-    await store.setup()
-    await store.teardown()
+    await eventStore.setup()
+    await eventStore.teardown()
 
     expect(
-      store.dynamodb.describeTable({TableName: store.tableName}).promise()
+      eventStore.dynamodb
+        .describeTable({TableName: eventStore.tableName})
+        .promise()
     ).rejects.toMatchObject({code: 'ResourceNotFoundException'})
   })
 })

--- a/tests/packages/core/Aggregate/commands.test.ts
+++ b/tests/packages/core/Aggregate/commands.test.ts
@@ -11,10 +11,10 @@ import {describeWithResources} from 'support'
 describe('Aggregate', () => {
   describeWithResources('executeCommand()', {stores: true}, context => {
     it('hydrates and retries on VersionConflictError', async () => {
-      const {store} = context
+      const {eventStore} = context
 
       class TestAggregate extends Aggregate {
-        public static store = store
+        public static eventStore = eventStore
 
         public async myCommand() {
           return await this.commit({
@@ -37,10 +37,10 @@ describe('Aggregate', () => {
 
   describeWithResources('executeCommand()', {stores: true}, context => {
     it('allows you to ensure consistency', async () => {
-      const {store} = context
+      const {eventStore} = context
 
       class TestAggregate extends Aggregate {
-        public static store = store
+        public static eventStore = eventStore
         public static stateReducer(state = {}, event: EventWithMetadata) {
           switch (event.type) {
             case 'Submitted': {
@@ -76,10 +76,10 @@ describe('Aggregate', () => {
 
   describeWithResources('commands', {stores: true}, context => {
     test('retryCommand decorator', async () => {
-      const {store} = context
+      const {eventStore} = context
 
       class TestAggregate extends Aggregate {
-        public static store = store
+        public static eventStore = eventStore
         public static stateReducer(state = {}, event: EventWithMetadata) {
           switch (event.type) {
             case 'Submitted': {

--- a/tests/packages/core/Aggregate/instance-commit.test.ts
+++ b/tests/packages/core/Aggregate/instance-commit.test.ts
@@ -5,10 +5,10 @@ import {describeWithResources, iterableToArray} from 'support'
 
 describeWithResources('Aggregate', {stores: true}, context => {
   test('commit()', async () => {
-    const {store} = context
+    const {eventStore} = context
     //
     class TestAggregate extends Aggregate {
-      public static store = store
+      public static eventStore = eventStore
     }
     const aggregate = new TestAggregate()
 
@@ -23,7 +23,8 @@ describeWithResources('Aggregate', {stores: true}, context => {
     expect(commitB).toHaveProperty('chronologicalGroup', 'default')
 
     const commitsInStore = await iterableToArray(
-      TestAggregate.store.queryAggregateCommits('TestAggregate', '@').commits
+      TestAggregate.eventStore.queryAggregateCommits('TestAggregate', '@')
+        .commits
     )
 
     expect(commitsInStore).toContainEqual(commitA)
@@ -33,10 +34,10 @@ describeWithResources('Aggregate', {stores: true}, context => {
 
 describeWithResources('Aggregate', {stores: true}, context => {
   test('commit() - custom chronologicalGroup', async () => {
-    const {store} = context
+    const {eventStore} = context
     //
     class TestAggregate extends Aggregate {
-      public static store = store
+      public static eventStore = eventStore
       public static chronologicalGroup = 'custom'
     }
     const aggregate = new TestAggregate()
@@ -52,7 +53,8 @@ describeWithResources('Aggregate', {stores: true}, context => {
     expect(commitB).toHaveProperty('chronologicalGroup', 'custom')
 
     const commitsInStore = await iterableToArray(
-      TestAggregate.store.queryAggregateCommits('TestAggregate', '@').commits
+      TestAggregate.eventStore.queryAggregateCommits('TestAggregate', '@')
+        .commits
     )
 
     expect(commitsInStore).toContainEqual(commitA)

--- a/tests/packages/core/Aggregate/loadOrCreate.test.ts
+++ b/tests/packages/core/Aggregate/loadOrCreate.test.ts
@@ -1,15 +1,15 @@
 import {
   Aggregate,
   Commit,
+  EventStore,
   EventWithMetadata,
   KeySchema,
-  Store,
   utils,
 } from '@ddes/core'
 import {describeWithResources} from 'support'
 
 class TestAggregate extends Aggregate {
-  public static store = {} as Store
+  public static eventStore = {} as EventStore
   public static keySchema = new KeySchema(['id'])
 
   public static stateReducer(state: any, event: EventWithMetadata) {
@@ -33,7 +33,7 @@ class TestAggregate extends Aggregate {
 
 describeWithResources('Aggregate.loadOrCreate()', {stores: true}, context => {
   beforeAll(() => {
-    TestAggregate.store = context.store
+    TestAggregate.eventStore = context.eventStore
   })
 
   test('when does not already exist', async () => {
@@ -46,7 +46,7 @@ describeWithResources('Aggregate.loadOrCreate()', {stores: true}, context => {
   })
 
   test('when already exists', async () => {
-    TestAggregate.store = context.store
+    TestAggregate.eventStore = context.eventStore
 
     await TestAggregate.commit('test', [
       {type: 'Created', properties: {id: 'test', name: 'initial'}},

--- a/tests/packages/core/Aggregate/static-commit.test.ts
+++ b/tests/packages/core/Aggregate/static-commit.test.ts
@@ -5,10 +5,10 @@ import {describeWithResources, iterableToArray} from 'support'
 
 describeWithResources('Aggregate', {stores: true}, context => {
   test('static commit() - no keySchema', async () => {
-    const {store} = context
+    const {eventStore} = context
     //
     class TestAggregate extends Aggregate {
-      public static store = store
+      public static eventStore = eventStore
     }
 
     const a = TestAggregate.commit([
@@ -21,7 +21,8 @@ describeWithResources('Aggregate', {stores: true}, context => {
     const [commitA, commitB] = await Promise.all([a, b])
 
     const commitsInStore = await iterableToArray(
-      TestAggregate.store.queryAggregateCommits('TestAggregate', '@').commits
+      TestAggregate.eventStore.queryAggregateCommits('TestAggregate', '@')
+        .commits
     )
 
     expect(commitsInStore).toContainEqual(commitA)
@@ -31,11 +32,11 @@ describeWithResources('Aggregate', {stores: true}, context => {
 
 describeWithResources('Aggregate', {stores: true}, context => {
   test('static commit() - with keySchema', async () => {
-    const {store} = context
+    const {eventStore} = context
     //
     class TestAggregate extends Aggregate {
       public static keySchema = new KeySchema(['id'])
-      public static store = store
+      public static eventStore = eventStore
     }
 
     const a = TestAggregate.commit('myid', [
@@ -47,7 +48,8 @@ describeWithResources('Aggregate', {stores: true}, context => {
 
     const [commitA, commitB] = await Promise.all([a, b])
     const commitsInStore = await iterableToArray(
-      TestAggregate.store.queryAggregateCommits('TestAggregate', 'myid').commits
+      TestAggregate.eventStore.queryAggregateCommits('TestAggregate', 'myid')
+        .commits
     )
     expect(commitsInStore).toContainEqual(commitA)
     expect(commitsInStore).toContainEqual(commitB)
@@ -56,11 +58,11 @@ describeWithResources('Aggregate', {stores: true}, context => {
 
 describeWithResources('Aggregate', {stores: true}, context => {
   test('static commit() - custom chronological group', async () => {
-    const {store} = context
+    const {eventStore} = context
     //
     class TestAggregate extends Aggregate {
       public static keySchema = new KeySchema(['id'])
-      public static store = store
+      public static eventStore = eventStore
       public static chronologicalGroup = 'custom'
     }
 
@@ -77,7 +79,8 @@ describeWithResources('Aggregate', {stores: true}, context => {
     expect(commitB).toHaveProperty('chronologicalGroup', 'custom')
 
     const commitsInStore = await iterableToArray(
-      TestAggregate.store.queryAggregateCommits('TestAggregate', 'myid').commits
+      TestAggregate.eventStore.queryAggregateCommits('TestAggregate', 'myid')
+        .commits
     )
     expect(commitsInStore).toContainEqual(commitA)
     expect(commitsInStore).toContainEqual(commitB)

--- a/tests/packages/core/BatchMutator.test.ts
+++ b/tests/packages/core/BatchMutator.test.ts
@@ -30,13 +30,13 @@ const upcasters: AggregateEventUpcasters = {
 describeWithResources('Stores', {stores: true}, context => {
   describe('BatchMutator', () => {
     test('without target capacity', async () => {
-      const {store} = context
+      const {eventStore} = context
 
       for (const commit of commits) {
-        await store.commit(commit)
+        await eventStore.commit(commit)
       }
 
-      const batchMutator = store.createBatchMutator()
+      const batchMutator = eventStore.createBatchMutator()
 
       await batchMutator.delete(commits[1])
       await batchMutator.put(
@@ -49,7 +49,7 @@ describeWithResources('Stores', {stores: true}, context => {
 
       await expect(
         iterableToArray(
-          store.queryAggregateCommits('TestAggregate', 'a').commits
+          eventStore.queryAggregateCommits('TestAggregate', 'a').commits
         )
       ).resolves.toMatchObject([
         {
@@ -73,13 +73,13 @@ describeWithResources('Stores', {stores: true}, context => {
 describeWithResources('Stores', {stores: true}, context => {
   describe('BatchMutator', () => {
     test('with target capacity', async () => {
-      const {store} = context
+      const {eventStore} = context
 
       for (const commit of commits) {
-        await store.commit(commit)
+        await eventStore.commit(commit)
       }
 
-      const batchMutator = store.createBatchMutator({
+      const batchMutator = eventStore.createBatchMutator({
         capacityLimit: 5,
       })
 
@@ -94,7 +94,7 @@ describeWithResources('Stores', {stores: true}, context => {
 
       await expect(
         iterableToArray(
-          store.queryAggregateCommits('TestAggregate', 'a').commits
+          eventStore.queryAggregateCommits('TestAggregate', 'a').commits
         )
       ).resolves.toMatchObject([
         {

--- a/tests/packages/core/Store/chronologicalQuery.test.ts
+++ b/tests/packages/core/Store/chronologicalQuery.test.ts
@@ -49,140 +49,144 @@ const commits = {
   }),
 }
 
-describeWithResources('Store.chronologicalQuery()', {stores: true}, context => {
-  beforeAll(async () => {
-    const {store} = context
+describeWithResources(
+  'eventStore.chronologicalQuery()',
+  {stores: true},
+  context => {
+    beforeAll(async () => {
+      const {eventStore} = context
 
-    for (const commit of Object.values(commits)) {
-      await store.commit(commit)
-    }
-  })
+      for (const commit of Object.values(commits)) {
+        await eventStore.commit(commit)
+      }
+    })
 
-  test('inclusive range in ascending order', async () => {
-    const {store} = context
+    test('inclusive range in ascending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: new Date('2018-01-02'),
-          max: new Date('2018-01-05'),
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.b1, commits.c1, commits.a2, commits.a3])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: new Date('2018-01-02'),
+            max: new Date('2018-01-05'),
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.b1, commits.c1, commits.a2, commits.a3])
+    })
 
-  test('inclusive range in descending order', async () => {
-    const {store} = context
+    test('inclusive range in descending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: new Date('2018-01-02'),
-          max: new Date('2018-01-05'),
-          descending: true,
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.a3, commits.a2, commits.c1, commits.b1])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: new Date('2018-01-02'),
+            max: new Date('2018-01-05'),
+            descending: true,
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.a3, commits.a2, commits.c1, commits.b1])
+    })
 
-  test('exclusiveMin = true in ascending order', async () => {
-    const {store} = context
+    test('exclusiveMin = true in ascending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: commits.a2.sortKey,
-          exclusiveMin: true,
-          max: new Date('2018-01-06'),
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.a3])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: commits.a2.sortKey,
+            exclusiveMin: true,
+            max: new Date('2018-01-06'),
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.a3])
+    })
 
-  test('exclusiveMin = true in descending order', async () => {
-    const {store} = context
+    test('exclusiveMin = true in descending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: commits.a2.sortKey,
-          exclusiveMin: true,
-          max: new Date('2018-01-06'),
-          descending: true,
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.a3])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: commits.a2.sortKey,
+            exclusiveMin: true,
+            max: new Date('2018-01-06'),
+            descending: true,
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.a3])
+    })
 
-  test('exclusiveMax = true in ascending order', async () => {
-    const {store} = context
+    test('exclusiveMax = true in ascending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: new Date('2018-01-03'),
-          max: commits.a3.sortKey,
-          exclusiveMax: true,
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.c1, commits.a2])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: new Date('2018-01-03'),
+            max: commits.a3.sortKey,
+            exclusiveMax: true,
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.c1, commits.a2])
+    })
 
-  test('exclusiveMax = true in descending order', async () => {
-    const {store} = context
+    test('exclusiveMax = true in descending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: new Date('2018-01-03'),
-          max: commits.a3.sortKey,
-          exclusiveMax: true,
-          descending: true,
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.a2, commits.c1])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: new Date('2018-01-03'),
+            max: commits.a3.sortKey,
+            exclusiveMax: true,
+            descending: true,
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.a2, commits.c1])
+    })
 
-  test('non-default partition', async () => {
-    const {store} = context
+    test('non-default partition', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          group: 'other',
-          min: new Date('2018-01-02'),
-          max: new Date('2018-01-06'),
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.o1])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            group: 'other',
+            min: new Date('2018-01-02'),
+            max: new Date('2018-01-06'),
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.o1])
+    })
 
-  test('limit and ascending order', async () => {
-    const {store} = context
+    test('limit and ascending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: new Date('2018-01-02'),
-          max: new Date('2018-01-05'),
-          limit: 2,
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.b1, commits.c1])
-  })
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: new Date('2018-01-02'),
+            max: new Date('2018-01-05'),
+            limit: 2,
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.b1, commits.c1])
+    })
 
-  test('limit and descending order', async () => {
-    const {store} = context
+    test('limit and descending order', async () => {
+      const {eventStore} = context
 
-    await expect(
-      iterableToArray(
-        store.chronologicalQuery({
-          min: new Date('2018-01-02'),
-          max: new Date('2018-01-05'),
-          limit: 2,
-          descending: true,
-        }).commits
-      )
-    ).resolves.toMatchObject([commits.a3, commits.a2])
-  })
-})
+      await expect(
+        iterableToArray(
+          eventStore.chronologicalQuery({
+            min: new Date('2018-01-02'),
+            max: new Date('2018-01-05'),
+            limit: 2,
+            descending: true,
+          }).commits
+        )
+      ).resolves.toMatchObject([commits.a3, commits.a2])
+    })
+  }
+)

--- a/tests/packages/core/Store/commit.test.ts
+++ b/tests/packages/core/Store/commit.test.ts
@@ -3,7 +3,7 @@ import {describeWithResources, iterableToArray} from 'support'
 
 describeWithResources('Stores', {stores: true}, context => {
   test('commit()', async () => {
-    const {store} = context
+    const {eventStore} = context
 
     const commit = new Commit({
       aggregateType: 'Test',
@@ -16,9 +16,9 @@ describeWithResources('Stores', {stores: true}, context => {
       chronologicalGroup: 'default',
     })
 
-    await store.commit(commit)
+    await eventStore.commit(commit)
     await expect(
-      iterableToArray(store.queryAggregateCommits('Test', 'test').commits)
+      iterableToArray(eventStore.queryAggregateCommits('Test', 'test').commits)
     ).resolves.toMatchObject([commit])
   })
 })

--- a/tests/packages/core/Store/getAggregateHeadCommit.test.ts
+++ b/tests/packages/core/Store/getAggregateHeadCommit.test.ts
@@ -3,7 +3,7 @@ import {describeWithResources} from 'support'
 
 describeWithResources('Stores', {stores: true}, context => {
   test('getAggregateHeadCommit()', async () => {
-    const {store} = context
+    const {eventStore} = context
 
     const commits = {
       a1: new Commit({
@@ -45,14 +45,14 @@ describeWithResources('Stores', {stores: true}, context => {
     }
 
     for (const commit of Object.values(commits)) {
-      await store.commit(commit)
+      await eventStore.commit(commit)
     }
 
     await expect(
-      store.getAggregateHeadCommit('Test', 'a')
+      eventStore.getAggregateHeadCommit('Test', 'a')
     ).resolves.toMatchObject(commits.a3)
     await expect(
-      store.getAggregateHeadCommit('Test', 'b')
+      eventStore.getAggregateHeadCommit('Test', 'b')
     ).resolves.toMatchObject(commits.b1)
   })
 })

--- a/tests/packages/core/Store/getHeadCommit.test.ts
+++ b/tests/packages/core/Store/getHeadCommit.test.ts
@@ -3,7 +3,7 @@ import {describeWithResources} from 'support'
 
 describeWithResources('Stores', {stores: true}, context => {
   test('getHeadCommit()', async () => {
-    const {store} = context
+    const {eventStore} = context
 
     const commits = {
       a1: {
@@ -41,9 +41,9 @@ describeWithResources('Stores', {stores: true}, context => {
     }
 
     for (const commit of Object.values(commits)) {
-      await store.commit(new Commit(commit))
+      await eventStore.commit(new Commit(commit))
     }
 
-    await expect(store.getHeadCommit()).resolves.toMatchObject(commits.a3)
+    await expect(eventStore.getHeadCommit()).resolves.toMatchObject(commits.a3)
   })
 })

--- a/tests/packages/core/Store/queryAggregateCommits.test.ts
+++ b/tests/packages/core/Store/queryAggregateCommits.test.ts
@@ -3,7 +3,7 @@ import {describeWithResources, iterableToArray} from 'support'
 
 describeWithResources('Stores', {stores: true}, context => {
   test('*queryAggregateCommits()', async () => {
-    const {store} = context
+    const {eventStore} = context
 
     const commits = {
       a1: new Commit({
@@ -45,19 +45,19 @@ describeWithResources('Stores', {stores: true}, context => {
     }
 
     for (const commit of Object.values(commits)) {
-      await store.commit(commit)
+      await eventStore.commit(commit)
     }
 
     {
       const result = await iterableToArray(
-        store.queryAggregateCommits('Test', 'a').commits
+        eventStore.queryAggregateCommits('Test', 'a').commits
       )
       expect(result).toMatchObject([commits.a1, commits.a2, commits.a3])
     }
 
     {
       const result = await iterableToArray(
-        store.queryAggregateCommits('Test', 'b').commits
+        eventStore.queryAggregateCommits('Test', 'b').commits
       )
       expect(result).toMatchObject([commits.b1])
     }
@@ -65,7 +65,7 @@ describeWithResources('Stores', {stores: true}, context => {
     // maxVersion
     {
       const result = await iterableToArray(
-        store.queryAggregateCommits('Test', 'a', {
+        eventStore.queryAggregateCommits('Test', 'a', {
           maxVersion: 2,
         }).commits
       )
@@ -75,7 +75,7 @@ describeWithResources('Stores', {stores: true}, context => {
     // minVersion
     {
       const result = await iterableToArray(
-        store.queryAggregateCommits('Test', 'a', {
+        eventStore.queryAggregateCommits('Test', 'a', {
           minVersion: 2,
         }).commits
       )
@@ -85,7 +85,7 @@ describeWithResources('Stores', {stores: true}, context => {
     // key + maxTime
     {
       const result = await iterableToArray(
-        store.queryAggregateCommits('Test', 'a', {
+        eventStore.queryAggregateCommits('Test', 'a', {
           maxTime: new Date('2018-01-02'),
         }).commits
       )

--- a/tests/scenarios/event-streaming/basic-event-streaming.test.ts
+++ b/tests/scenarios/event-streaming/basic-event-streaming.test.ts
@@ -1,4 +1,4 @@
-import {Commit, Store} from '@ddes/core'
+import {Commit, EventStore} from '@ddes/core'
 import {EventSubscriber} from '@ddes/event-streaming'
 import {describeWithResources, iterableToArray} from 'support'
 
@@ -51,7 +51,7 @@ describeWithResources(
   context => {
     test('single client with no filter', async () => {
       const {eventStreamServer} = context
-      const store = context.store as Store
+      const eventStore = context.eventStore
 
       const subscriptionStream = new EventSubscriber({
         wsUrl: `ws://localhost:${eventStreamServer.port}`,
@@ -61,7 +61,7 @@ describeWithResources(
       const iterator = subscriptionStream[Symbol.asyncIterator]()
 
       for (const commit of getTestCommits()) {
-        await store.commit(commit)
+        await eventStore.commit(commit)
       }
 
       await expect(
@@ -106,7 +106,7 @@ describeWithResources(
   context => {
     test('single client with filter on aggregateType', async () => {
       const {eventStreamServer} = context
-      const store = context.store as Store
+      const eventStore = context.eventStore
 
       const subscriptionStream = new EventSubscriber({
         wsUrl: `ws://localhost:${eventStreamServer.port}`,
@@ -116,7 +116,7 @@ describeWithResources(
       const iterator = subscriptionStream[Symbol.asyncIterator]()
 
       for (const commit of getTestCommits()) {
-        await store.commit(commit)
+        await eventStore.commit(commit)
       }
 
       await expect(
@@ -151,7 +151,7 @@ describeWithResources(
   context => {
     test('deep property filter', async () => {
       const {eventStreamServer} = context
-      const store = context.store as Store
+      const eventStore = context.eventStore
 
       const subscriptionStream = new EventSubscriber({
         wsUrl: `ws://localhost:${eventStreamServer.port}`,
@@ -161,7 +161,7 @@ describeWithResources(
       const iterator = subscriptionStream[Symbol.asyncIterator]()
 
       for (const commit of getTestCommits()) {
-        await store.commit(commit)
+        await eventStore.commit(commit)
       }
 
       await expect(
@@ -188,7 +188,7 @@ describeWithResources(
   context => {
     test('multiple clients', async () => {
       const {eventStreamServer} = context
-      const store = context.store as Store
+      const eventStore = context.eventStore
 
       const subscriptionStream1 = new EventSubscriber({
         wsUrl: `ws://localhost:${eventStreamServer.port}`,
@@ -201,7 +201,7 @@ describeWithResources(
       })
 
       for (const commit of getTestCommits()) {
-        await store.commit(commit)
+        await eventStore.commit(commit)
       }
 
       await expect(

--- a/tests/scenarios/projections/basic.test.ts
+++ b/tests/scenarios/projections/basic.test.ts
@@ -101,7 +101,7 @@ describeWithResources('Projections', {stores: true}, context => {
     await projectionB.setup({startsAt: new Date()})
 
     const projector = new Projector([projectionA, projectionB], {
-      store: context.store,
+      eventStore: context.eventStore,
     })
 
     projector.start()
@@ -109,7 +109,7 @@ describeWithResources('Projections', {stores: true}, context => {
     const testCommits = []
 
     for (const commit of getTestCommits()) {
-      await context.store.commit(commit)
+      await context.eventStore.commit(commit)
       testCommits.push(commit)
     }
 

--- a/tests/scenarios/projections/dependencies.test.ts
+++ b/tests/scenarios/projections/dependencies.test.ts
@@ -105,7 +105,7 @@ describeWithResources('Projections', {stores: true}, context => {
     await projectionA.setup({startsAt: new Date()})
 
     const projector = new Projector([projectionA], {
-      store: context.store,
+      eventStore: context.eventStore,
     })
 
     projector.start()
@@ -113,7 +113,7 @@ describeWithResources('Projections', {stores: true}, context => {
     const testCommits = []
 
     for (const commit of getTestCommits()) {
-      await context.store.commit(commit)
+      await context.eventStore.commit(commit)
       testCommits.push(commit)
     }
 

--- a/tests/scenarios/store-transformations/commit-copy-and-transformation.test.ts
+++ b/tests/scenarios/store-transformations/commit-copy-and-transformation.test.ts
@@ -11,8 +11,8 @@ describeWithResources(
   context => {
     // we need to get target store
     test(`modifying commit`, async () => {
-      const {store: source} = context
-      const target = aws({testId: context.testId + '-target'}, {})
+      const {eventStore: source} = context
+      const target = aws.eventStore({testId: context.testId + '-target'}, {})
       context.teardownFunctions.push(() => target.teardown())
       await target.setup()
 
@@ -99,8 +99,8 @@ describeWithResources(
   {stores: true},
   context => {
     test('deleting commit', async () => {
-      const {store: source} = context
-      const target = aws({testId: context.testId + '-target'}, {})
+      const {eventStore: source} = context
+      const target = aws.eventStore({testId: context.testId + '-target'}, {})
       context.teardownFunctions.push(() => target.teardown())
       await target.setup()
 
@@ -170,8 +170,8 @@ describeWithResources(
   {stores: true},
   context => {
     test('creating new commits', async () => {
-      const {store: source} = context
-      const target = aws({testId: context.testId + '-target'}, {})
+      const {eventStore: source} = context
+      const target = aws.eventStore({testId: context.testId + '-target'}, {})
       context.teardownFunctions.push(() => target.teardown())
       await target.setup()
 

--- a/tests/scenarios/store-transformations/commit-in-place-transformation.test.ts
+++ b/tests/scenarios/store-transformations/commit-in-place-transformation.test.ts
@@ -9,9 +9,9 @@ describeWithResources(
   {stores: true},
   context => {
     test(`modifying commit`, async () => {
-      const {store} = context
+      const {eventStore} = context
 
-      await store.commit(
+      await eventStore.commit(
         new Commit({
           aggregateType: 'AggregateB',
           aggregateKey: 'key',
@@ -20,7 +20,7 @@ describeWithResources(
         })
       )
 
-      await store.commit(
+      await eventStore.commit(
         new Commit({
           aggregateType: 'AggregateA',
           aggregateKey: 'key',
@@ -34,8 +34,8 @@ describeWithResources(
 
       const transformation = new CommitTransformation({
         name: 'test',
-        source: store,
-        target: store,
+        source: eventStore,
+        target: eventStore,
 
         async transform(commit: Commit) {
           switch (commit.aggregateType) {
@@ -61,7 +61,7 @@ describeWithResources(
       await transformer.execute()
 
       await expect(
-        iterableToArray(store.scan().commits)
+        iterableToArray(eventStore.scan().commits)
       ).resolves.toMatchObject([
         {
           aggregateKey: 'key',
@@ -85,9 +85,9 @@ describeWithResources(
   {stores: true},
   context => {
     test('deleting commit', async () => {
-      const {store} = context
+      const {eventStore} = context
 
-      await store.commit(
+      await eventStore.commit(
         new Commit({
           aggregateType: 'AggregateA',
           aggregateKey: 'key',
@@ -96,7 +96,7 @@ describeWithResources(
         })
       )
 
-      await store.commit(
+      await eventStore.commit(
         new Commit({
           aggregateType: 'AggregateB',
           aggregateKey: 'key',
@@ -107,8 +107,8 @@ describeWithResources(
 
       const transformation = new CommitTransformation({
         name: 'test',
-        source: store,
-        target: store,
+        source: eventStore,
+        target: eventStore,
 
         async transform(commit: Commit) {
           switch (commit.aggregateType) {
@@ -130,7 +130,7 @@ describeWithResources(
       await transformer.execute()
 
       await expect(
-        iterableToArray(store.scan().commits)
+        iterableToArray(eventStore.scan().commits)
       ).resolves.toMatchObject([
         {
           aggregateKey: 'key',
@@ -148,9 +148,9 @@ describeWithResources(
   {stores: true},
   context => {
     test('creating new commits', async () => {
-      const {store} = context
+      const {eventStore} = context
 
-      await store.commit(
+      await eventStore.commit(
         new Commit({
           aggregateType: 'AggregateA',
           aggregateKey: 'key',
@@ -159,7 +159,7 @@ describeWithResources(
         })
       )
 
-      await store.commit(
+      await eventStore.commit(
         new Commit({
           aggregateType: 'AggregateB',
           aggregateKey: 'key',
@@ -170,8 +170,8 @@ describeWithResources(
 
       const transformation = new CommitTransformation({
         name: 'test',
-        source: store,
-        target: store,
+        source: eventStore,
+        target: eventStore,
 
         async transform(commit: Commit) {
           switch (commit.aggregateType) {
@@ -196,7 +196,7 @@ describeWithResources(
       await transformer.execute()
 
       await expect(
-        iterableToArray(store.scan().commits)
+        iterableToArray(eventStore.scan().commits)
       ).resolves.toMatchObject([
         {
           aggregateKey: 'key',

--- a/tests/support/resources/eventStreamServer.ts
+++ b/tests/support/resources/eventStreamServer.ts
@@ -1,8 +1,13 @@
-import {Store} from '@ddes/core'
+import {EventStore} from '@ddes/core'
 import {EventStreamer} from '@ddes/event-streaming'
 
-export async function eventStreamServer(store: Store) {
-  const server = new EventStreamer({store: (store as any) as Store, port: 0})
+export async function eventStreamServer(context: {eventStore: EventStore}) {
+  const {eventStore} = context
+
+  const server = new EventStreamer({
+    eventStore,
+    port: 0,
+  })
   const port = (server.wss as any)._server.address().port
 
   const teardown = async () => {

--- a/tests/support/stores/aws.ts
+++ b/tests/support/stores/aws.ts
@@ -1,9 +1,17 @@
-import {AwsMetaStore, AwsStore, AwsStoreConfig} from '@ddes/aws-store'
+import {
+  AwsEventStore,
+  AwsMetaStore,
+  AwsSnapshotStore,
+  AwsEventStoreConfig,
+} from '@ddes/aws-store'
 
-export function aws(opts: {testId: string}, config: Partial<AwsStoreConfig>) {
+export function eventStore(
+  opts: {testId: string},
+  config: Partial<AwsEventStoreConfig>
+) {
   const {testId} = opts
 
-  return new AwsStore({
+  return new AwsEventStore({
     tableName: `ddes-${testId}`,
     ...(!process.env.REAL_SERVICES_TEST && {
       s3ClientConfiguration: {
@@ -23,16 +31,11 @@ export function aws(opts: {testId: string}, config: Partial<AwsStoreConfig>) {
         secretAccessKey: 'test',
       },
     }),
-    snapshots: {
-      s3BucketName: `ddess-${testId}`,
-      keyPrefix: 'snapshots/',
-      manageBucket: true,
-    },
     ...config,
   })
 }
 
-export function awsMeta(opts: {testId: string}) {
+export function metaStore(opts: {testId: string}) {
   const {testId} = opts
 
   return new AwsMetaStore({
@@ -45,5 +48,25 @@ export function awsMeta(opts: {testId: string}) {
         secretAccessKey: 'test',
       },
     }),
+  })
+}
+
+export function snapshotStore(opts: {testId: string}) {
+  const {testId} = opts
+
+  return new AwsSnapshotStore({
+    ...(!process.env.REAL_SERVICES_TEST && {
+      s3ClientConfiguration: {
+        endpoint: process.env.LOCAL_S3 || 'http://localhost:5000',
+        sslEnabled: false,
+        s3ForcePathStyle: true,
+        accessKeyId: 'test',
+        secretAccessKey: 'test',
+        region: 'us-east-1',
+      },
+    }),
+    bucketName: `ddes-${testId}`,
+    keyPrefix: 'snapshots/',
+    manageBucket: true,
   })
 }

--- a/tests/support/stores/index.ts
+++ b/tests/support/stores/index.ts
@@ -1,1 +1,2 @@
-export * from './aws'
+import * as aws from './aws'
+export {aws}


### PR DESCRIPTION
Moved snapshot responsibility to SnapshotStore (AwsSnapshotStore) and
renamed Store to EventStore (AwsEventStore).

BREAKING CHANGE: Store no longer exists, Aggregate configuration changed

Aggregate configuration changes:
  * static property 'store' is now 'eventStore'.
  * static property 'useSnapshots' replaced by optionally setting
    'snapshotStore' static property.