### PR TITLE
Committing multiple aggregates in a transaction

### DIFF
--- a/packages/@ddes/core/lib/AggregateRoot.ts
+++ b/packages/@ddes/core/lib/AggregateRoot.ts
@@ -183,14 +183,13 @@ export class AggregateRoot<
   }
 
   /**
-   * Commit aggregate events to the store
-   * TODO include info about VersionConflictError
+   * Build aggregate commit from events without saving it to the store
    */
-  async commit(
+  build(
     key: string | TKeyProps,
     version: number,
     events: TEvent[]
-  ): Promise<AggregateCommit<TEvent, TAggregateType>> {
+  ): AggregateCommit<TEvent, TAggregateType> {
     const aggregateKey = typeof key === 'string' ? key : this.keyFromProps(key)
 
     const commitData = {
@@ -205,6 +204,20 @@ export class AggregateRoot<
       ...commitData,
       chronologicalKey: this.config.store.chronologicalKey(commitData),
     }
+
+    return commit
+  }
+
+  /**
+   * Commit aggregate events to the store
+   * TODO include info about VersionConflictError
+   */
+  async commit(
+    key: string | TKeyProps,
+    version: number,
+    events: TEvent[]
+  ): Promise<AggregateCommit<TEvent, TAggregateType>> {
+    const commit: AggregateCommit<TEvent, TAggregateType> = this.build(key, version, events)
 
     return await this.config.store.commit<AggregateCommit<TEvent, TAggregateType>>(commit)
   }

--- a/packages/@ddes/postgres/lib/PostgresEventStore.ts
+++ b/packages/@ddes/postgres/lib/PostgresEventStore.ts
@@ -74,7 +74,7 @@ export class PostgresEventStore extends EventStore {
 
   public async commit<TAggregateCommit extends AggregateCommit>(commit: TAggregateCommit) {
     try {
-      await this.commitOne(this.pool, commit)
+      await this.insertCommit(this.pool, commit)
     } catch (error: any) {
       if (error.code === '23505') {
         throw new VersionConflictError(commit)
@@ -85,7 +85,7 @@ export class PostgresEventStore extends EventStore {
     return commit
   }
 
-  private async commitOne<TAggregateCommit extends AggregateCommit>(
+  private async insertCommit<TAggregateCommit extends AggregateCommit>(
     pool: Pool,
     commit: TAggregateCommit
   ) {


### PR DESCRIPTION
## Motivation

We would like to have consistency when aggregates with dependencies are saved to the database. In a case where two aggregates will be committed to in the same flow, it makes sense to be able to rollback both if one of them fails to commit due to a conflict.

## New APIs

### @ddes/core

* added `AggregateRoot.build`, which accepts the same arguments as `AggregateRoot.commit` and returns an `AggregateCommit`

### @ddes/postgres

* added `PostgresEventStore.commitInTransaction` which will accept a list of `AggregateCommit`s obtained through `AggregateRoot.build`

## Example

```ts
const myStore = new PostgresEventStore({})

await retryOnVersionConflict(async () => {
  // Assume currentFooVersion and currentBarVersion is set

  const firstCommit = SomeAggregate.build('foo', currentFooVersion + 1, [{ type: 'SomeEvent' }])
  const secondCommit = OtherAggregate.build('bar', currentBarVersion + 1, [{ type: 'AnotherEvent' }])

  await myStore.commitInTransaction([
    firstCommit,
    secondCommit,
  ])
})

// vs the existing approach
await retryOnVersionConflict(async () => {
  // Assume currentFooVersion and currentBarVersion is set

  await SomeAggregate.commit('foo', currentFooVersion + 1, [{ type: 'SomeEvent' }])
  
  // If this next line fails, the commit above will not be rolled back in the database
  await OtherAggregate.commit('bar', currentBarVersion + 1, [{ type: 'AnotherEvent' }])
})
```